### PR TITLE
Fix require path in helper spec

### DIFF
--- a/spec/helpers/query_helper_spec.cr
+++ b/spec/helpers/query_helper_spec.cr
@@ -1,5 +1,5 @@
 require "../spec_helper"
-require "../helpers/query_helper_spec"
+require "../../src/helpers/query_helper"
 
 class DumbController
   include Helpers::QueryHelper


### PR DESCRIPTION
```crystal spec``` was giving me the following error:
```
$ crystal spec
Error in line 2: while requiring "./spec/helpers/query_helper_spec.cr"

in spec/helpers/query_helper_spec.cr:5: undefined constant Helpers::QueryHelper

  include Helpers::QueryHelper
          ^~~~~~~~~~~~~~~~~~~~
```

I think the problem is that the require path is referencing the same file. :smile: 