### PR TITLE
Spec to Spec2

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -72,6 +72,10 @@ shards:
     github: jeromegn/slang
     commit: b817c89c7e5ae39562710c0d6c7f42cee685e14f
 
+  spec2:
+    github: waterlink/spec2.cr
+    version: 0.11.0
+
   twitter:
     github: veelenga/twitter.cr
     commit: d70d460a2f8edb2961e1da2b44382bfb2dfd61bf

--- a/shard.yml
+++ b/shard.yml
@@ -36,3 +36,7 @@ dependencies:
   hashids:
     github: splattael/hashids.cr
     version: 0.2.1
+
+development_dependencies:
+  spec2:
+    github: waterlink/spec2.cr

--- a/spec/helpers/page_title_helper_spec.cr
+++ b/spec/helpers/page_title_helper_spec.cr
@@ -10,11 +10,11 @@ describe Helpers::PageTitleHelper do
     it "sets page title" do
       controller = DumbController.new
       controller.page_title "my page title"
-      controller.page_title.should eq "my page title - #{SITE.name}"
+      expect(controller.page_title).to eq "my page title - #{SITE.name}"
     end
 
     it "returns default site title with suffix" do
-      DumbController.new.page_title.should eq "#{SITE.description} - #{SITE.name}"
+      expect(DumbController.new.page_title).to eq "#{SITE.description} - #{SITE.name}"
     end
   end
 end

--- a/spec/helpers/query_helper_spec.cr
+++ b/spec/helpers/query_helper_spec.cr
@@ -10,30 +10,30 @@ end
 describe Helpers::QueryHelper do
   describe "#to_query" do
     it "encodes empty params when query is empty" do
-      DumbController.new.to_query.should eq ""
+      expect(DumbController.new.to_query).to eq ""
     end
 
     it "encodes params when query is empty" do
       controller = DumbController.new
       controller.params = HTTP::Params.parse "foo=bar&qux=zoo"
-      controller.to_query.should eq "foo=bar&qux=zoo"
+      expect(controller.to_query).to eq "foo=bar&qux=zoo"
     end
 
     it "encodes params and query" do
       controller = DumbController.new
       controller.params = HTTP::Params.parse "foo=bar&qux=zoo"
-      controller.to_query(page: 22).should eq "foo=bar&qux=zoo&page=22"
+      expect(controller.to_query page: 22).to eq "foo=bar&qux=zoo&page=22"
     end
 
     it "encodes params and query and overrides params values" do
       controller = DumbController.new
       controller.params = HTTP::Params.parse "foo=bar&qux=zoo&page=1"
-      controller.to_query(page: 22).should eq "foo=bar&qux=zoo&page=22"
+      expect(controller.to_query page: 22).to eq "foo=bar&qux=zoo&page=22"
     end
 
     it "encodes only query when params are empty" do
       controller = DumbController.new
-      controller.to_query(page: 22, foo: "bar").should eq "page=22&foo=bar"
+      expect(controller.to_query page: 22, foo: "bar").to eq "page=22&foo=bar"
     end
   end
 end

--- a/spec/initializers/database_spec.cr
+++ b/spec/initializers/database_spec.cr
@@ -1,11 +1,12 @@
 require "../spec_helper"
 
 describe DBSettings do
-  %w(test development staging production).each do |env|
-    db = DBSettings.load env
+  {% for env in %w(test development staging production) %}
 
-    it "has database_url in #{env} environment" do
-      db.database_url.blank?.should eq false
+    it "has database_url in {{env.id}} environment" do
+      db = DBSettings.load {{env}}
+      expect(db.database_url.blank?).to eq false
     end
-  end
+
+  {% end %}
 end

--- a/spec/initializers/site_spec.cr
+++ b/spec/initializers/site_spec.cr
@@ -2,34 +2,34 @@ require "../spec_helper"
 
 describe SiteSettings do
   it "loads SITE settings" do
-    SITE.should_not eq nil
+    expect(SITE).not_to be_nil
   end
 
   it "loads SITE.name" do
-    SITE.name.blank?.should eq false
+    expect(SITE.name.blank?).to be_false
   end
 
   it "loads SITE.description" do
-    SITE.description.blank?.should eq false
+    expect(SITE.description.blank?).to be_false
   end
 
   it "loads SITE.url" do
-    SITE.url.blank?.should eq false
+    expect(SITE.url.blank?).to be_false
   end
 
-  %w(development staging production).each do |env|
-    site = SiteSettings.load env
+  {% for env in %w(test development staging production) %}
+    let(:site) { SiteSettings.load {{env}} }
 
-    it "has name in #{env} environment" do
-      site.name.blank?.should eq false
+    it "has name in {{env.id}} environment" do
+      expect(site.name.blank?).to be_false
     end
 
-    it "has description in #{env} environment" do
-      site.description.blank?.should eq false
+    it "has description in {{env.id}} environment" do
+      expect(site.description.blank?).to be_false
     end
 
-    it "has url in #{env} environment" do
-      site.url.blank?.should eq false
+    it "has url in {{env.id}} environment" do
+      expect(site.url.blank?).to be_false
     end
-  end
+  {% end %}
 end

--- a/spec/models/announcement_spec.cr
+++ b/spec/models/announcement_spec.cr
@@ -4,83 +4,79 @@ require "../../src/models/announcement.cr"
 describe Announcement do
   describe "Validation" do
     it "succeeds on valid parameters" do
-      announcement(title: "test title").valid?.should eq true
+      expect(announcement.valid?).to be_true
     end
 
     it "requires title" do
-      announcement(title: "").valid?.should eq false
+      expect(announcement(title: "").valid?).to be_false
     end
 
     it "validates minimum size of title" do
-      announcement(title: "-" * 3).valid?.should eq false
+      expect(announcement(title: "-" * 3).valid?).to be_false
     end
 
     it "validates maximum size of title" do
-      announcement(title: "-" * 101).valid?.should eq false
+      expect(announcement(title: "-" * 101).valid?).to be_false
     end
 
     it "requires description" do
-      announcement(description: "").valid?.should eq false
+      expect(announcement(description: "").valid?).to be_false
     end
 
     it "validates minimum size of description" do
-      announcement(description: "-" * 3).valid?.should eq false
+      expect(announcement(description: "-" * 3).valid?).to be_false
     end
 
     it "validates maximum size of description" do
-      announcement(description: "-" * 4001).valid?.should eq false
+      expect(announcement(description: "-" * 4001).valid?).to be_false
     end
 
     it "validates type" do
-      announcement(type: -1).valid?.should eq false
+      expect(announcement(type: -1).valid?).to be_false
     end
   end
 
   describe "#typename" do
     it "returns the name of the type" do
       Announcement::TYPES.each do |type, name|
-        announcement(type: type).typename.should eq name
+        expect(announcement(type: type).typename).to eq name
       end
     end
 
     it "raises error if type is wrong" do
-      expect_raises { announcement(type: -1).typename }
+      raise_error { announcement(type: -1).typename }
     end
   end
 
   describe "#content" do
     it "returns html content" do
-      announcement(description: "test").content.should eq "<p>test</p>"
+      expect(announcement(description: "test").content).to eq "<p>test</p>"
     end
 
     it "encodes html tags" do
-      announcement(description: "<script>console.log('hello')</script>")
-        .content.should eq "<p>&lt;script>console.log('hello')&lt;/script></p>"
+      ann = announcement(description: "<script>console.log('hello')</script>")
+      expect(ann.content).to eq "<p>&lt;script>console.log('hello')&lt;/script></p>"
     end
   end
 
   describe "#short_path" do
     it "returns short path to the announcement" do
-      announcement(title: "first announcement")
-        .tap { |a| a.id = 1_i64 }
-        .short_path.should eq "/=D49Nz"
+      expect(announcement.tap { |a| a.id = 1_i64 }.short_path).to eq "/=D49Nz"
     end
 
     it "returns nil if announcement does not have id" do
-      announcement(title: "second announcement")
-        .short_path.should eq nil
+      expect(announcement.short_path).to eq nil
     end
   end
 
   describe "#hashid" do
     it "returns nil if id is not present" do
-      announcement(title: "hashid test").hashid.should eq nil
+      expect(announcement.hashid).to eq nil
     end
 
     it "returns hash id if id is present" do
-      announcement(title: "hashid test")
-        .tap { |a| a.id = 1_i64 }
-        .hashid.should eq "D49Nz"
+      hashid = announcement.tap { |a| a.id = 1_i64 }.hashid
+      expect(hashid).to eq "D49Nz"
     end
   end
 end

--- a/spec/models/spec_helper.cr
+++ b/spec/models/spec_helper.cr
@@ -7,8 +7,9 @@ def user(**params)
     :uid      => "123123",
     :login    => "johndoe",
     :provider => "github",
-  }.merge!(params.to_h)
+  } of Symbol => String | Int64
 
+  params.each { |k, v| attributes[k] = v }
   User.new attributes
 end
 
@@ -18,7 +19,8 @@ def announcement(**params)
     :title       => "title",
     :description => "description",
     :type        => Announcement::TYPES.keys.first,
-  }.merge!(params.to_h)
+  } of Symbol => String | Int64 | Int32
 
+  params.each { |k, v| attributes[k] = v }
   Announcement.new attributes
 end

--- a/spec/models/user_spec.cr
+++ b/spec/models/user_spec.cr
@@ -4,53 +4,51 @@ require "../../src/models/user.cr"
 describe User do
   describe "Validation" do
     it "succeeds on valid parameters" do
-      user(login: "john").valid?.should eq true
+      expect(user.valid?).to be_true
     end
 
     it "requires login not to be blank" do
-      user(login: "").valid?.should eq false
+      expect(user(login: "").valid?).to be_false
     end
 
     it "requires uid not to be blank" do
-      user(uid: "").valid?.should eq false
+      expect(user(uid: "").valid?).to be_false
     end
 
     it "requires provider not to be blank" do
-      user(provider: "").valid?.should eq false
+      expect(user(provider: "").valid?).to be_false
     end
   end
 
   describe "#admin?" do
     it "returns false if roles does not equal to admin" do
-      user(role: "user").admin?.should eq false
+      expect(user(role: "user").admin?).to be_false
     end
 
     it "returns true if roles equals to admin" do
-      user(role: "admin").admin?.should eq true
+      expect(user(role: "admin").admin?).to be_true
     end
 
     it "returns false if roles is not specified" do
-      user(uid: "123").admin?.should eq false
+      expect(user.admin?).to be_false
     end
   end
 
   describe "#can_update?" do
     it "returns true if announcement belongs to the user" do
-      user = user(login: "anny").tap { |u| u.id = 1_i64 }
+      user = user().tap { |u| u.id = 1_i64 }
       announcement = announcement(user_id: user.id.not_nil!)
-      user.can_update?(announcement).should eq true
+      expect(user.can_update? announcement).to be_true
     end
 
     it "returns false if announcement does not belong to the user" do
-      user = user(login: "mike").tap { |u| u.id = 1_i64 }
       announcement = announcement(user_id: 2_i64)
-      user.can_update?(announcement).should eq false
+      expect(user.can_update? announcement).to be_false
     end
 
     it "returns true if user is admin and announcement does not belong to the user" do
-      user = user(role: "admin")
       announcement = announcement(user_id: 2_i64)
-      user.can_update?(announcement).should eq true
+      expect(user(role: "admin").can_update? announcement).to be_true
     end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,8 @@
 ENV["AMBER_ENV"] = "test"
 
-require "spec"
+require "spec2"
 require "amber"
 require "../config/application"
 require "../db/migrate"
+
+include Spec2::GlobalDSL

--- a/spec/workers/tweet_announcement_spec.cr
+++ b/spec/workers/tweet_announcement_spec.cr
@@ -1,32 +1,33 @@
 require "../spec_helper"
+require "../../src/workers/tweet_announcement"
 
 describe Workers::TweetAnnouncement do
-  worker = Workers::TweetAnnouncement.new
-  announcement = Announcement.new({
-    :id          => 1_i64,
-    :title       => "First Announcement",
-    :description => "Super cool stuff created",
-  })
+  subject { Workers::TweetAnnouncement.new }
+  let(:announcement) {
+    Announcement.new({
+      :id          => 1_i64,
+      :title       => "First Announcement",
+      :description => "Super cool stuff created",
+    })
+  }
 
   describe "#tweet_template" do
+    let(:template) { subject.tweet_template announcement }
+
     it "includes announcement title" do
-      worker.tweet_template(announcement)
-            .includes?(announcement.title.to_s).should eq true
+      expect(template.includes? announcement.title.to_s).to eq true
     end
 
     it "includes SITE.url" do
-      worker.tweet_template(announcement)
-            .includes?(SITE.url).should eq true
+      expect(template.includes? SITE.url).to eq true
     end
 
     it "includes announcement.short_path" do
-      worker.tweet_template(announcement)
-            .includes?(announcement.short_path.to_s).should eq true
+      expect(template.includes? announcement.short_path.to_s).to eq true
     end
 
     it "includes #crystallang hashtag" do
-      worker.tweet_template(announcement)
-            .includes?("#crystallang").should eq true
+      expect(template.includes? "#crystallang").to eq true
     end
   end
 end


### PR DESCRIPTION
https://github.com/waterlink/spec2.cr

Spec2 is much more convenient and powerful. `before`/`after`, `let`/`let!`, matchers and `expect` are really handy.

### Running time

`spec`:   `~10 milliseconds`
`spec2`: `~18 milliseconds`

So, does not really matter.

### Credits

@waterlink 😼 