### PR TITLE
Filter by announcement type

### DIFF
--- a/spec/models/announcement_spec.cr
+++ b/spec/models/announcement_spec.cr
@@ -79,4 +79,34 @@ describe Announcement do
       expect(hashid).to eq "D49Nz"
     end
   end
+
+  describe "#typename_underscore" do
+    it "returns the type with underscores" do
+      expect(announcement(type: 0).typename_underscore).to eq "blog_post"
+      expect(announcement(type: 1).typename_underscore).to eq "project_update"
+      expect(announcement(type: 2).typename_underscore).to eq "conference"
+      expect(announcement(type: 3).typename_underscore).to eq "meetup"
+      expect(announcement(type: 4).typename_underscore).to eq "podcast"
+      expect(announcement(type: 5).typename_underscore).to eq "screencast"
+      expect(announcement(type: 6).typename_underscore).to eq "video"
+      expect(announcement(type: 7).typename_underscore).to eq "other"
+    end
+  end
+
+  describe ".reverse_typename_underscore" do
+    it "returns nil if is invalid" do
+      expect(Announcement.reverse_typename_underscore("foo")).to eq nil
+    end
+
+    it "returns the type given a typename_underscore" do
+      expect(Announcement.reverse_typename_underscore("blog_post")).to eq 0
+      expect(Announcement.reverse_typename_underscore("project_update")).to eq 1
+      expect(Announcement.reverse_typename_underscore("conference")).to eq 2
+      expect(Announcement.reverse_typename_underscore("meetup")).to eq 3
+      expect(Announcement.reverse_typename_underscore("podcast")).to eq 4
+      expect(Announcement.reverse_typename_underscore("screencast")).to eq 5
+      expect(Announcement.reverse_typename_underscore("video")).to eq 6
+      expect(Announcement.reverse_typename_underscore("other")).to eq 7
+    end
+  end
 end

--- a/spec/models/announcement_spec.cr
+++ b/spec/models/announcement_spec.cr
@@ -37,10 +37,15 @@ describe Announcement do
   end
 
   describe "#typename" do
-    it "returns the name of the type" do
-      Announcement::TYPES.each do |type, name|
-        expect(announcement(type: type).typename).to eq name
-      end
+    it "returns the properly capitalized type name" do
+      expect(announcement(type: 0).typename).to eq "Blog Post"
+      expect(announcement(type: 1).typename).to eq "Project Update"
+      expect(announcement(type: 2).typename).to eq "Conference"
+      expect(announcement(type: 3).typename).to eq "Meetup"
+      expect(announcement(type: 4).typename).to eq "Podcast"
+      expect(announcement(type: 5).typename).to eq "Screencast"
+      expect(announcement(type: 6).typename).to eq "Video"
+      expect(announcement(type: 7).typename).to eq "Other"
     end
 
     it "raises error if type is wrong" do
@@ -77,36 +82,6 @@ describe Announcement do
     it "returns hash id if id is present" do
       hashid = announcement.tap { |a| a.id = 1_i64 }.hashid
       expect(hashid).to eq "D49Nz"
-    end
-  end
-
-  describe "#typename_underscore" do
-    it "returns the type with underscores" do
-      expect(announcement(type: 0).typename_underscore).to eq "blog_post"
-      expect(announcement(type: 1).typename_underscore).to eq "project_update"
-      expect(announcement(type: 2).typename_underscore).to eq "conference"
-      expect(announcement(type: 3).typename_underscore).to eq "meetup"
-      expect(announcement(type: 4).typename_underscore).to eq "podcast"
-      expect(announcement(type: 5).typename_underscore).to eq "screencast"
-      expect(announcement(type: 6).typename_underscore).to eq "video"
-      expect(announcement(type: 7).typename_underscore).to eq "other"
-    end
-  end
-
-  describe ".reverse_typename_underscore" do
-    it "returns nil if is invalid" do
-      expect(Announcement.reverse_typename_underscore("foo")).to eq nil
-    end
-
-    it "returns the type given a typename_underscore" do
-      expect(Announcement.reverse_typename_underscore("blog_post")).to eq 0
-      expect(Announcement.reverse_typename_underscore("project_update")).to eq 1
-      expect(Announcement.reverse_typename_underscore("conference")).to eq 2
-      expect(Announcement.reverse_typename_underscore("meetup")).to eq 3
-      expect(Announcement.reverse_typename_underscore("podcast")).to eq 4
-      expect(Announcement.reverse_typename_underscore("screencast")).to eq 5
-      expect(Announcement.reverse_typename_underscore("video")).to eq 6
-      expect(Announcement.reverse_typename_underscore("other")).to eq 7
     end
   end
 end

--- a/src/controllers/announcement_controller.cr
+++ b/src/controllers/announcement_controller.cr
@@ -5,10 +5,10 @@ class AnnouncementController < ApplicationController
   PER_PAGE = 10
 
   def index
-    query, current_page = query_param, page_param
-    total_pages = Announcement.count(query).fdiv(PER_PAGE).ceil.to_i
+    query, current_page, type = query_param, page_param, type_param
+    total_pages = Announcement.count(query, type).fdiv(PER_PAGE).ceil.to_i
 
-    announcements = Announcement.search(query, per_page: PER_PAGE, page: current_page)
+    announcements = Announcement.search(query, per_page: PER_PAGE, page: current_page, type: type)
     render("index.slang")
   end
 
@@ -97,5 +97,9 @@ class AnnouncementController < ApplicationController
 
   private def page_param
     [params.fetch("page", "1").to_i { 1 }, 1].max
+  end
+
+  private def type_param
+    Announcement.reverse_typename_underscore(params["type"]?.try &.gsub(/[^0-9A-Za-z_\-\s]/, ""))
   end
 end

--- a/src/controllers/announcement_controller.cr
+++ b/src/controllers/announcement_controller.cr
@@ -100,6 +100,6 @@ class AnnouncementController < ApplicationController
   end
 
   private def type_param
-    Announcement.reverse_typename_underscore(params["type"]?.try &.gsub(/[^0-9A-Za-z_\-\s]/, ""))
+    Announcement::TYPES.key(params["type"]?.try &.gsub(/[^0-9A-Za-z_\-\s]/, "")) { nil }
   end
 end

--- a/src/controllers/announcement_controller.cr
+++ b/src/controllers/announcement_controller.cr
@@ -100,6 +100,6 @@ class AnnouncementController < ApplicationController
   end
 
   private def type_param
-    Announcement::TYPES.key(params["type"]?.try &.gsub(/[^0-9A-Za-z_\-\s]/, "")) { nil }
+    (type = params["type"]?) && Announcement::TYPES.key(type) { -1 }
   end
 end

--- a/src/models/announcement.cr
+++ b/src/models/announcement.cr
@@ -47,7 +47,6 @@ class Announcement < Granite::ORM
                  else
                    ["%#{query}%", per_page, (page - 1) * per_page]
                  end
-    puts q
     self.all q, parameters
   end
 

--- a/src/models/announcement.cr
+++ b/src/models/announcement.cr
@@ -3,14 +3,14 @@ require "markdown"
 
 class Announcement < Granite::ORM
   TYPES = {
-    0 => "Blog Post",
-    1 => "Project Update",
-    2 => "Conference",
-    3 => "Meetup",
-    4 => "Podcast",
-    5 => "Screencast",
-    6 => "Video",
-    7 => "Other",
+    0 => "blog_post",
+    1 => "project_update",
+    2 => "conference",
+    3 => "meetup",
+    4 => "podcast",
+    5 => "screencast",
+    6 => "video",
+    7 => "other",
   }
 
   adapter pg
@@ -38,28 +38,22 @@ class Announcement < Granite::ORM
 
   def self.search(query, per_page = nil, page = 1, type = nil)
     q = %Q{
-      WHERE (title ILIKE $1 OR description ILIKE $1) #{(type ? "AND type = $4" : "")}
+      WHERE (title ILIKE $1 OR description ILIKE $1) #{"AND type = $4" if type}
       ORDER BY created_at DESC
       LIMIT $2 OFFSET $3
     }
-    parameters = if type
-                   ["%#{query}%", per_page, (page - 1) * per_page, type]
-                 else
-                   ["%#{query}%", per_page, (page - 1) * per_page]
-                 end
+    parameters = ["%#{query}%", per_page, (page - 1) * per_page]
+    parameters << type if type
     self.all q, parameters
   end
 
   def self.count(query, type = nil)
-    parameters = if type
-                   ["%#{query}%", type]
-                 else
-                   "%#{query}%"
-                 end
+    parameters = ["%#{query}%"] of String | Int32
+    parameters << type if type
     @@adapter.open do |db|
       db.scalar(%Q{
         SELECT COUNT(*) FROM announcements
-        WHERE (title ILIKE $1 OR description ILIKE $1) #{(type ? "AND type = $2" : "")}
+        WHERE (title ILIKE $1 OR description ILIKE $1) #{"AND type = $2" if type}
       }, parameters).as(Int64)
     end
   end
@@ -91,17 +85,7 @@ class Announcement < Granite::ORM
   end
 
   def typename
-    TYPES[type]
-  end
-
-  def typename_underscore
-    typename.tr(" ", "").underscore
-  end
-
-  def self.reverse_typename_underscore(typename)
-    index = nil
-    TYPES.each { |i, type| index = i if type.tr(" ", "").underscore == typename }
-    index
+    TYPES[type].split("_").map(&.capitalize).join(" ")
   end
 
   def user

--- a/src/views/announcement/_entry.slang
+++ b/src/views/announcement/_entry.slang
@@ -20,7 +20,7 @@ article.hentry
 
     span.tags-links
       i.fa.fa-tag
-      a href="?type=#{Announcement::TYPES[announcement.type]}"
+      a href="/?type=#{Announcement::TYPES[announcement.type]}"
         = announcement.typename
 
     - if can_update?(announcement)

--- a/src/views/announcement/_entry.slang
+++ b/src/views/announcement/_entry.slang
@@ -20,7 +20,8 @@ article.hentry
 
     span.tags-links
       i.fa.fa-tag
-      = announcement.typename
+      a href="?type=#{announcement.typename_underscore}"
+        = announcement.typename
 
     - if can_update?(announcement)
       span.actions

--- a/src/views/announcement/_entry.slang
+++ b/src/views/announcement/_entry.slang
@@ -20,7 +20,7 @@ article.hentry
 
     span.tags-links
       i.fa.fa-tag
-      a href="?type=#{announcement.typename_underscore}"
+      a href="?type=#{Announcement::TYPES[announcement.type]}"
         = announcement.typename
 
     - if can_update?(announcement)


### PR DESCRIPTION
Following the idea from #5, this adds a filter by announcement type when clicking on the tag name.