### PR TITLE
Move to crystal-community org

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ MICRATE_RUN_UP=true crystal spec
 
 ```
 $ heroku create app-name --buildpack https://github.com/crystal-lang/heroku-buildpack-crystal.git
-$ heroku buildpacks:add https://github.com/crystal-announcements/heroku-buildpack-sidekiq.cr
+$ heroku buildpacks:add https://github.com/veelenga/heroku-buildpack-sidekiq.cr
 $ git push heroku master
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Crystal [ANN]
-[![Build Status](https://travis-ci.org/crystal-announcements/crystal-ann.svg?branch=master)](https://travis-ci.org/crystal-announcements/crystal-ann)
+[![Build Status](https://travis-ci.org/crystal-community/crystal-ann.svg?branch=master)](https://travis-ci.org/crystal-community/crystal-ann)
 [![Amber Framework](https://img.shields.io/badge/using-amber%20framework-orange.svg)](http://www.ambercr.io/)
 [![Gitter](https://badges.gitter.im/veelenga/crystal-ann.svg)](https://gitter.im/veelenga/crystal-ann?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 

--- a/shard.lock
+++ b/shard.lock
@@ -5,7 +5,7 @@ shards:
     version: 0.1.6
 
   autolink:
-    github: crystal-announcements/autolink.cr
+    github: crystal-community/autolink.cr
     version: 0.1.3
 
   baked_file_system:
@@ -81,7 +81,7 @@ shards:
     version: 0.11.0
 
   twitter:
-    github: crystal-announcements/twitter.cr
+    github: crystal-community/twitter.cr
     commit: 8008e54c24a715b933b64e974fefa527e769a189
 
   webmock:

--- a/shard.yml
+++ b/shard.yml
@@ -33,13 +33,13 @@ dependencies:
     branch: master
 
   twitter:
-    github: crystal-announcements/twitter.cr
+    github: veelenga/twitter.cr
 
   hashids:
     github: splattael/hashids.cr
 
   autolink:
-    github: crystal-announcements/autolink.cr
+    github: crystal-community/autolink.cr
     version: 0.1.3
 
 development_dependencies:

--- a/src/views/layouts/_footer.slang
+++ b/src/views/layouts/_footer.slang
@@ -8,7 +8,7 @@ div.site-info
     a href="/about" = "About"
     a href="/rss" = "RSS"
     a href="https://twitter.com/crystallang_ann" target="_blank" = "Twitter"
-    a href="https://github.com/crystal-announcements/crystal-ann" target="_blank" = "Github"
+    a href="https://github.com/crystal-community/crystal-ann" target="_blank" = "Github"
 
   div.footer-block
     h3 = "Crystal Language"

--- a/src/views/layouts/_social_nav.slang
+++ b/src/views/layouts/_social_nav.slang
@@ -6,7 +6,7 @@ nav#social-navigation.social-navigation
           i.fa.fa-twitter.fa-2x
 
       li
-        a href="https://github.com/crystal-announcements/crystal-ann" target="_blank"
+        a href="https://github.com/crystal-community/crystal-ann" target="_blank"
           i.fa.fa-github.fa-2x
 
       li

--- a/src/views/static/about.slang
+++ b/src/views/static/about.slang
@@ -50,6 +50,6 @@ div.page-content
           a href="https://twitter.com/crystallang_ann" target="_blank" = "Twitter"
       li
         | Give it a star, report an issue or propose a change on
-          a href="https://github.com/crystal-announcements/crystal-ann" target="_blank" = "Github"
+          a href="https://github.com/crystal-community/crystal-ann" target="_blank" = "Github"
       li
         | Love Crystal ;)


### PR DESCRIPTION
Fixed #29 

TODO: 

* [x] point travis to use crystal-community org instead of crystal-announcements.