### PR TITLE
Upgrade granite-orm version

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -18,7 +18,7 @@ shards:
 
   granite_orm:
     github: kemalyst/granite-orm
-    version: 0.6.4
+    version: 0.7.2
 
   hashids:
     github: splattael/hashids.cr
@@ -34,11 +34,7 @@ shards:
 
   kemal-session:
     github: kemalcr/kemal-session
-    commit: 5cb3b5b207db92852651a7b7ec4f95d6478f8580
-
-  kemalyst-validators:
-    github: kemalyst/kemalyst-validators
-    version: 0.2.0
+    commit: ec08bfe302d6ddbd1b33c5283d56a8b496cdb276
 
   kilt:
     github: jeromegn/kilt
@@ -81,7 +77,7 @@ shards:
     version: 0.11.0
 
   twitter:
-    github: crystal-community/twitter.cr
+    github: veelenga/twitter.cr
     commit: 8008e54c24a715b933b64e974fefa527e769a189
 
   webmock:

--- a/shard.yml
+++ b/shard.yml
@@ -16,7 +16,7 @@ dependencies:
 
   granite_orm:
     github: kemalyst/granite-orm
-    version: ~> 0.6.4
+    version: 0.7.2
  
   pg:
     github: will/crystal-pg

--- a/src/models/announcement.cr
+++ b/src/models/announcement.cr
@@ -2,7 +2,7 @@ require "granite_orm/adapter/pg"
 require "markdown"
 require "autolink"
 
-class Announcement < Granite::ORM
+class Announcement < Granite::ORM::Base
   TYPES = {
     0 => "blog_post",
     1 => "project_update",

--- a/src/models/user.cr
+++ b/src/models/user.cr
@@ -1,6 +1,6 @@
 require "granite_orm/adapter/pg"
 
-class User < Granite::ORM
+class User < Granite::ORM::Base
   adapter pg
 
   # id : Int64 primary key is created for you


### PR DESCRIPTION
Follwing #34, this PR upgrades granite-orm version to v0.7.2 (latest).

Fix #33.