### PR TITLE
Improve announcement footer

### DIFF
--- a/spec/models/announcement_spec.cr
+++ b/spec/models/announcement_spec.cr
@@ -38,8 +38,8 @@ describe Announcement do
 
   describe "#typename" do
     it "returns the properly capitalized type name" do
-      expect(announcement(type: 0).typename).to eq "Blog Post"
-      expect(announcement(type: 1).typename).to eq "Project Update"
+      expect(announcement(type: 0).typename).to eq "Blog post"
+      expect(announcement(type: 1).typename).to eq "Project update"
       expect(announcement(type: 2).typename).to eq "Conference"
       expect(announcement(type: 3).typename).to eq "Meetup"
       expect(announcement(type: 4).typename).to eq "Podcast"

--- a/src/models/announcement.cr
+++ b/src/models/announcement.cr
@@ -65,7 +65,7 @@ class Announcement < Granite::ORM::Base
   end
 
   def self.typename(type)
-    TYPES[type].split("_").map(&.capitalize).join(" ")
+    TYPES[type].split("_").join(" ").capitalize
   end
 
   def next

--- a/src/views/announcement/_entry.slang
+++ b/src/views/announcement/_entry.slang
@@ -6,12 +6,6 @@ article.hentry
   div.entry-content == announcement.content
 
   footer.entry-footer
-    span.posted-on
-      time.entry-date.published.updated
-        i.fa.fa-calendar
-        a href="/announcements/#{ announcement.id }" title="#{announcement.created_at.try &.to_s "%b %d, %Y"}"
-          = time_ago_in_words(announcement.created_at.not_nil!)
-
     - if user = announcement.user
       span.byline
         span.author.vcard
@@ -24,6 +18,12 @@ article.hentry
       i.fa.fa-tag
       a href="/?#{to_query type: Announcement::TYPES[announcement.type], page: 1}"
         = announcement.typename
+
+    span.posted-on
+      time.entry-date.published.updated
+        i.fa.fa-clock-o
+        a href="/announcements/#{ announcement.id }" title="#{announcement.created_at.try &.to_s "%b %d, %Y"}"
+          = time_ago_in_words(announcement.created_at.not_nil!)
 
     - if can_update?(announcement)
       span.actions

--- a/src/views/announcement/_entry.slang
+++ b/src/views/announcement/_entry.slang
@@ -6,18 +6,18 @@ article.hentry
   div.entry-content == announcement.content
 
   footer.entry-footer
+    span.tags-links
+      i.fa.fa-tag
+      a href="/?#{to_query type: Announcement::TYPES[announcement.type], page: 1}"
+        = announcement.typename
+
     - if user = announcement.user
       span.byline
         span.author.vcard
           i.fa.fa-user
           a href="/users/#{user.login}"
             span.fn
-              = user.name
-
-    span.tags-links
-      i.fa.fa-tag
-      a href="/?#{to_query type: Announcement::TYPES[announcement.type], page: 1}"
-        = announcement.typename
+              = user.login
 
     span.posted-on
       time.entry-date.published.updated

--- a/src/views/layouts/_profile.slang
+++ b/src/views/layouts/_profile.slang
@@ -2,7 +2,7 @@ aside.widget.widget_meta
   h2.widget-title
     a href="/me"
       img.avatar src=current_user!.avatar_url(45)
-      = current_user!.name
+      = current_user!.login
 
   ul
     li


### PR DESCRIPTION
* changed calendar icon to clock 
* time ago in words are now upcase 

<img width="409" alt="screen shot 2017-09-21 at 12 15 06 am" src="https://user-images.githubusercontent.com/3624712/30668007-01dca970-9e62-11e7-8126-2e34370a04c7.png">
<img width="392" alt="screen shot 2017-09-21 at 12 15 25 am" src="https://user-images.githubusercontent.com/3624712/30668008-01e30496-9e62-11e7-8277-c1408d57cc6f.png">

Just looks a bit more pleasantly IMO. WDYT?