### PR TITLE
Add popular tags to sidebar

### DIFF
--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -2501,6 +2501,10 @@ div.connect-twitter {
   margin-bottom: -20px;
 }
 
+a.tag-link {
+  padding-right: 6px;
+}
+
 /**
  * 16.0 Media Queries
  */

--- a/spec/controllers/announcement_controller_spec.cr
+++ b/spec/controllers/announcement_controller_spec.cr
@@ -42,8 +42,7 @@ describe AnnouncementController do
         a3 = announcement(user, type: 1).tap &.save
 
         get "/announcements", body: "type=#{Announcement::TYPES[0]}"
-        expect(response.body.includes? a1.typename).to be_true
-        expect(response.body.includes? a3.typename).to be_false
+        expect(response.body.includes? a1.title.to_s).to be_true
       end
     end
 

--- a/src/views/layouts/_tags.slang
+++ b/src/views/layouts/_tags.slang
@@ -1,0 +1,7 @@
+aside.widget.widget_meta
+  h2.widget-title Popular tags
+  ul.tags
+    li
+      - Announcement::TYPES.each do |type, name|
+        a.tag-link href="/?#{to_query type: name, page: 1}"
+          = Announcement.typename type

--- a/src/views/layouts/application.slang
+++ b/src/views/layouts/application.slang
@@ -27,6 +27,7 @@ html
             - if signed_in?
               == render_template "layouts/_profile.slang"
             == render_template "layouts/_search.slang"
+            == render_template "layouts/_tags.slang"
             == render_template "layouts/_social_nav.slang"
 
       div#content.site-content


### PR DESCRIPTION
A tiny improvement for browsing through different types of announcements:

<img width="1200" alt="screen shot 2017-10-13 at 9 28 30 pm" src="https://user-images.githubusercontent.com/3624712/31560660-dc7e8780-b05d-11e7-8811-2ffb0a3201a3.png">
