### PR TITLE
Depend on hashids.cr `0.2.2`

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -38,6 +38,7 @@ dependencies:
 
   hashids:
     github: splattael/hashids.cr
+    version: 0.2.2
 
   autolink:
     github: crystal-community/autolink.cr


### PR DESCRIPTION
This version has support for Crystal 0.24.1 :neckbeard:

Refs https://github.com/splattael/hashids.cr/pull/2