### PR TITLE
Remove broken dependency badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Crystal [ANN]
 [![Build Status](https://travis-ci.org/crystal-community/crystal-ann.svg?branch=master)](https://travis-ci.org/crystal-community/crystal-ann)
-[![Dependency Status](https://shards.rocks/badge/github/crystal-community/crystal-ann/status.svg)](https://shards.rocks/github/crystal-community/crystal-ann)
 [![GitHub release](https://img.shields.io/github/release/crystal-community/crystal-ann.svg)](https://github.com/crystal-community/crystal-ann)
 [![Amber Framework](https://img.shields.io/badge/using-amber%20framework-orange.svg)](http://www.amberframework.org/)
 [![Gitter](https://badges.gitter.im/veelenga/crystal-ann.svg)](https://gitter.im/veelenga/crystal-ann?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)


### PR DESCRIPTION
The link from http://shards.rocks/badge/github/crystal-community/crystal-ann/status.svg causes a mysql error and therefore needs to be removed.